### PR TITLE
Feature(backend): Updated Profile Navbar To Pass Query to Explore Page

### DIFF
--- a/fwb/app/(auth)/(routes)/intakeform/page.tsx
+++ b/fwb/app/(auth)/(routes)/intakeform/page.tsx
@@ -14,6 +14,7 @@ import Select, { SelectChangeEvent } from "@mui/material/Select";
 import MenuItem from "@mui/material/MenuItem";
 import InputLabel from "@mui/material/InputLabel";
 import FormControl from "@mui/material/FormControl";
+import { useRouter } from "next/navigation";
 
 
 const theme = createTheme({
@@ -60,6 +61,14 @@ export default function Intakeform() {
   );
   const [categories, setCategories] = useState([]);
   const [termsAndConditions, setTermsAndConditions] = useState(false);
+
+  const router = useRouter();
+  const [companyQuery, setCompanyQuery] = useState('');
+
+  const handleSearch = (companyQuery: any) => {
+    const url = `/explore?company=${companyQuery}`;
+    router.push(url);
+  };
 
   const handleSlide = (event: Event, newValue: number | number[]) => {
     if (typeof newValue === "number") {
@@ -124,7 +133,7 @@ export default function Intakeform() {
       <Box sx={{ backgroundColor: "#1A1A23", minHeight: "100vh" }}>
       <Container disableGutters maxWidth="lg">
         <div>
-          <Navbar />
+          <Navbar handleSearch={handleSearch} companyQuery={companyQuery} setCompanyQuery={setCompanyQuery}/>
         </div>
         <form
           id="discountForm"

--- a/fwb/app/(auth)/(routes)/profile/Profile.tsx
+++ b/fwb/app/(auth)/(routes)/profile/Profile.tsx
@@ -15,6 +15,7 @@ import SaveIcon from "../../../../components/ui/profile/icons/save.svg";
 import BargainBackgroundImage from "../../public/bargain1700x350.png";
 import { UserData } from "../../../types/types";
 import EditProfileModal from "./EditProfileModal";
+import { useRouter } from "next/navigation";
 
 function Profile({ userData }: { userData: UserData }) {
   // Need to update font
@@ -35,11 +36,18 @@ function Profile({ userData }: { userData: UserData }) {
   };
 
   const { user } = useUser();
+  const router = useRouter();
+  const [companyQuery, setCompanyQuery] = useState('');
+
+  const handleSearch = (companyQuery: any) => {
+    const url = `/explore?company=${companyQuery}`;
+    router.push(url);
+  };
 
   return (
     <Box sx={{ backgroundColor: "#1A1A23", minHeight: "100vh" }}>
       <Container disableGutters maxWidth="lg">
-        <Navbar />
+        <Navbar handleSearch={handleSearch} companyQuery={companyQuery} setCompanyQuery={setCompanyQuery}/>
         <div className="bg-[#1a1a23] min-h-screen">
           {/*Container div*/}
           <div className="flex flex-1 flex-col h-full w-full items-center justify-center px-[120px]">

--- a/fwb/app/api/companies/[company_name]/route.ts
+++ b/fwb/app/api/companies/[company_name]/route.ts
@@ -1,9 +1,0 @@
-import { NextRequest, NextResponse } from "next/server";
-import { auth, currentUser } from "@clerk/nextjs";
-import supabaseClient from "@/supabase";
-import { getCompanyDiscounts } from "@/app/api/companies/[company_name]/utils/company_utils";
-
-// Get single user
-export async function GET(request: NextRequest) {
-  return (await getCompanyDiscounts(request));
-}

--- a/fwb/app/api/companies/search/route.ts
+++ b/fwb/app/api/companies/search/route.ts
@@ -8,11 +8,11 @@ import supabaseClient from "@/supabase";
  * @param request - The NextRequest object containing the query parameters.
  * @returns A NextResponse object containing the fetched users or an error response.
  */
-const getCompanyDiscounts = async (request: NextRequest) => {
+export async function GET(request: NextRequest) {
 
   //Extract the company_name from the url path
-  const urlObject = new URL(request.url)
-  const companyNamePathVariable = urlObject.pathname.split("/").pop()
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get('companyQuery');
 
   try {
     const { userId, getToken } = auth();
@@ -31,7 +31,7 @@ const getCompanyDiscounts = async (request: NextRequest) => {
       let { data: companyData, error } = await supabase
         .from("companies")
         .select("*")
-        .eq("name", companyNamePathVariable)
+        .eq("name", query)
 
       if (error) {
         return NextResponse.json(
@@ -55,5 +55,3 @@ const getCompanyDiscounts = async (request: NextRequest) => {
     );
   }
 };
-
-export { getCompanyDiscounts };

--- a/fwb/components/ui/profile/profile_navbar.tsx
+++ b/fwb/components/ui/profile/profile_navbar.tsx
@@ -30,7 +30,13 @@ const theme = createTheme({
   }
 })
 
-const SearchBar = () => {
+interface SearchBarProps {
+  handleSearch: (e: any) => void;
+  companyQuery: string;
+  setCompanyQuery: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const SearchBar: React.FC<SearchBarProps> = ({ handleSearch, companyQuery, setCompanyQuery }) => {
   return (
     <Box
       sx={{
@@ -47,20 +53,21 @@ const SearchBar = () => {
         placeholder="Search for more benefits"
         style={{ flex: 1, height: "48px", borderRadius: "25px 0 0 25px", justifyContent: "center"}}
         sx={{ "& .MuiOutlinedInput-notchedOutline": { border: "none" }, "&.MuiFormControl-root": { alignItems: "flex-start" } }}
+        value = {companyQuery}
+        onChange={(e) => setCompanyQuery(e.target.value)}
       />
       <IconButton
-        color="primary"
         aria-label="search"
         sx={{
           backgroundColor: "black",
           padding: "10px",
           border: "none",
           margin: "4px",
-          transition: 'backgroundColor 1s ease',
           '&:hover': {
             backgroundColor: '#8e94e9'
           }
         }}
+        onClick={() => handleSearch(companyQuery)}
       >
         <Image src={searchIcon} alt="Search Icon" />
       </IconButton>
@@ -68,7 +75,13 @@ const SearchBar = () => {
   );
 };
 
-export default function Navbar() {
+interface NavbarProps {
+  handleSearch: (e: any) => void;
+  companyQuery: string;
+  setCompanyQuery: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const Navbar: React.FC<NavbarProps> =({ handleSearch, companyQuery, setCompanyQuery }) => {
   const router = useRouter();
   const { signOut } = useClerk();
   const { user, isSignedIn } = useUser();
@@ -124,7 +137,7 @@ export default function Navbar() {
           variant="dense"
           sx={{ display: "flex", gap: "24px", height: "9.6px", flexGrow: 1 }}
         > 
-          <SearchBar />
+          <SearchBar handleSearch={handleSearch} companyQuery={companyQuery} setCompanyQuery={setCompanyQuery}/>
           <Tooltip 
             title="Explore"
             slotProps={{
@@ -292,3 +305,5 @@ export default function Navbar() {
     </ThemeProvider>
   )};
 }
+
+export default Navbar;


### PR DESCRIPTION
This Pull Request Does the Following
- Refactored company search API to use query parameters instead of path variables
- Allows User to search for company on Profile page and have it redirect them to explore page with that company searched for in Grid

TODO:
- Have to add this to Groups page. The way groups page is currently set up to handle async/await function calls prevents "use client" from being used which is necessary useState props being passed to Navbar Component on the page.