### PR TITLE
Update useIntitialChatClient to use username instead of fullname

### DIFF
--- a/fwb/app/chat/useIntializeChatClient.ts
+++ b/fwb/app/chat/useIntializeChatClient.ts
@@ -16,7 +16,7 @@ export default function useIntitialChatClient() {
       .connectUser(
         {
           id: user.id,
-          name: user.fullName || user.id,
+          name: user.username || user.id,
           image: user.imageUrl,
         },
         async () => {


### PR DESCRIPTION
Ticket: https://app.clickup.com/t/8687y544v

Change existing getStream db accounts to use usernames instead of full names. Future accounts will automatically display usernames. Current accounts will display the full names.