### PR TITLE
Fix(Frontend): Changed Placeholder text to black

### DIFF
--- a/fwb/app/(auth)/(routes)/profile/EditProfileModal.tsx
+++ b/fwb/app/(auth)/(routes)/profile/EditProfileModal.tsx
@@ -352,6 +352,7 @@ const EditProfileModal = ({
               }}
             >
               <input
+                className="placeholder-black"
                 type="text"
                 value={inputValue}
                 onChange={(e) => setInputValue(e.target.value)}
@@ -425,6 +426,7 @@ const EditProfileModal = ({
               }}
             >
               <input
+                className="placeholder-black"
                 type="text"
                 placeholder={
                   userData.users[0].company


### PR DESCRIPTION
This pull request was meant to address the hover behavior of the navbar but it is working as intended and moved that ticket to blocked for Sprint on Monday.

Instead this Pull Request focuses on changing the placeholder text of the Edit Profile Modal to black instead of grey.

<img width="933" alt="Screen Shot 2024-04-06 at 8 03 31 PM" src="https://github.com/j3cio/FWB/assets/106201853/d3bb0a2f-3169-436c-80aa-10594d6a651f">
