### PR TITLE
Fix(frontend): Removed tooltip blocking Navbar buttons

### DIFF
--- a/fwb/components/ui/navbar/DesktopNavbar.tsx
+++ b/fwb/components/ui/navbar/DesktopNavbar.tsx
@@ -96,6 +96,7 @@ const DesktopNavbar = ({
             />
             <Tooltip
               title="Explore"
+              disableInteractive={true}
               slotProps={{
                 popper: {
                   modifiers: [
@@ -136,6 +137,7 @@ const DesktopNavbar = ({
             </Tooltip>
             <Tooltip
               title="Groups"
+              disableInteractive={true}
               slotProps={{
                 popper: {
                   modifiers: [
@@ -179,6 +181,7 @@ const DesktopNavbar = ({
             </Tooltip>
             <Tooltip
               title="Messages"
+              disableInteractive={true}
               slotProps={{
                 popper: {
                   modifiers: [


### PR DESCRIPTION
-Added a line of code to the three tooltips in the Desktop Navbar Component that disables their interactivity. This is so when a user mouses up from the bottom of the button, the tooltip wont interfere with their navigation.