### PR TITLE
Hid back button in our search bar

### DIFF
--- a/fwb/app/chat/page.css
+++ b/fwb/app/chat/page.css
@@ -121,3 +121,7 @@
 /* Chat Message input*/
 .str-chat__message-input {
 }
+
+button[data-testid='search-bar-button'] {
+  display: none;
+}


### PR DESCRIPTION
https://app.clickup.com/t/8688hckub

Pretty self explanatory, when you go to `/chat`, a back button should no longer appear when you start typing in the searchbar